### PR TITLE
feat: add high-impact plugins (avante, trouble, spectre, todo-comments)

### DIFF
--- a/lua/mappings.lua
+++ b/lua/mappings.lua
@@ -61,6 +61,12 @@ map(
   { desc = "Toggle Floating Term" }
 )
 
+-- Trouble mappings
+map("n", "<leader>xx", "<cmd>Trouble diagnostics toggle<CR>", { desc = "Trouble: Workspace Diagnostics" })
+map("n", "<leader>xd", "<cmd>Trouble diagnostics toggle filter.buf=0<CR>", { desc = "Trouble: Buffer Diagnostics" })
+map("n", "<leader>xl", "<cmd>Trouble loclist toggle<CR>", { desc = "Trouble: Location List" })
+map("n", "<leader>xq", "<cmd>Trouble quickfix toggle<CR>", { desc = "Trouble: Quickfix List" })
+
 -- Linting mappings
 map("n", "<leader>l", "<cmd>lua require('lint').try_lint()<CR>", { desc = "Trigger linting for current file" })
 

--- a/lua/mappings.lua
+++ b/lua/mappings.lua
@@ -61,6 +61,12 @@ map(
   { desc = "Toggle Floating Term" }
 )
 
+-- Todo-comments mappings
+map("n", "<leader>td", "<cmd>TodoTelescope<CR>", { desc = "Todo: Search all TODOs" })
+map("n", "<leader>tl", "<cmd>Trouble todo toggle<CR>", { desc = "Todo: List in Trouble" })
+map("n", "]t", function() require("todo-comments").jump_next() end, { desc = "Todo: Next" })
+map("n", "[t", function() require("todo-comments").jump_prev() end, { desc = "Todo: Previous" })
+
 -- Spectre mappings (project-wide find & replace)
 map("n", "<leader>sr", "<cmd>lua require('spectre').open()<CR>", { desc = "Spectre: Open search & replace" })
 map("n", "<leader>sw", "<cmd>lua require('spectre').open_visual({select_word=true})<CR>", { desc = "Spectre: Search current word" })

--- a/lua/mappings.lua
+++ b/lua/mappings.lua
@@ -61,6 +61,11 @@ map(
   { desc = "Toggle Floating Term" }
 )
 
+-- Spectre mappings (project-wide find & replace)
+map("n", "<leader>sr", "<cmd>lua require('spectre').open()<CR>", { desc = "Spectre: Open search & replace" })
+map("n", "<leader>sw", "<cmd>lua require('spectre').open_visual({select_word=true})<CR>", { desc = "Spectre: Search current word" })
+map("v", "<leader>sw", "<esc><cmd>lua require('spectre').open_visual()<CR>", { desc = "Spectre: Search selection" })
+
 -- Trouble mappings
 map("n", "<leader>xx", "<cmd>Trouble diagnostics toggle<CR>", { desc = "Trouble: Workspace Diagnostics" })
 map("n", "<leader>xd", "<cmd>Trouble diagnostics toggle filter.buf=0<CR>", { desc = "Trouble: Buffer Diagnostics" })

--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -221,6 +221,14 @@ return {
     end,
   },
 
+  -- todo-comments.nvim — Highlight and search TODO/FIXME/HACK/NOTE in codebase
+  {
+    "folke/todo-comments.nvim",
+    dependencies = { "nvim-lua/plenary.nvim" },
+    event = { "BufReadPre", "BufNewFile" },
+    opts = {},
+  },
+
   -- nvim-spectre — Project-wide find and replace with regex + live preview
   {
     "nvim-pack/nvim-spectre",

--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -260,7 +260,7 @@ return {
     opts = {
       provider = "copilot",
       copilot = {
-        model = "claude-3.5-sonnet",
+        model = "claude-sonnet-4.6",
       },
       mappings = {
         ask = "<leader>aa",

--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -221,6 +221,14 @@ return {
     end,
   },
 
+  -- trouble.nvim — Better diagnostics list with workspace-wide errors/warnings
+  {
+    "folke/trouble.nvim",
+    dependencies = { "nvim-tree/nvim-web-devicons" },
+    cmd = "Trouble",
+    opts = {},
+  },
+
   -- avante.nvim — AI chat inside neovim (Claude/GPT context-aware code editing)
   {
     "yetone/avante.nvim",

--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -221,6 +221,14 @@ return {
     end,
   },
 
+  -- nvim-spectre — Project-wide find and replace with regex + live preview
+  {
+    "nvim-pack/nvim-spectre",
+    dependencies = { "nvim-lua/plenary.nvim" },
+    cmd = "Spectre",
+    opts = {},
+  },
+
   -- trouble.nvim — Better diagnostics list with workspace-wide errors/warnings
   {
     "folke/trouble.nvim",

--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -221,6 +221,34 @@ return {
     end,
   },
 
+  -- avante.nvim — AI chat inside neovim (Claude/GPT context-aware code editing)
+  {
+    "yetone/avante.nvim",
+    event = "VeryLazy",
+    version = false,
+    build = "make",
+    dependencies = {
+      "nvim-treesitter/nvim-treesitter",
+      "stevearc/dressing.nvim",
+      "nvim-lua/plenary.nvim",
+      "MunifTanjim/nui.nvim",
+    },
+    opts = {
+      provider = "copilot",
+      copilot = {
+        model = "claude-3.5-sonnet",
+      },
+      mappings = {
+        ask = "<leader>aa",
+        edit = "<leader>ae",
+        refresh = "<leader>ar",
+        toggle = {
+          default = "<leader>at",
+        },
+      },
+    },
+  },
+
   -- "nvim-lua/plenary.nvim",
   --
   -- {


### PR DESCRIPTION
## What

Adds 4 high-impact plugins to improve development workflow:

### 1. avante.nvim — AI code chat & editing
- Context-aware AI chat inside neovim (uses Copilot provider, no extra API key)
- Ask questions about your codebase, refactor selections, get explanations
- `<leader>aa` ask, `<leader>ae` edit, `<leader>at` toggle panel

### 2. trouble.nvim — Workspace diagnostics panel
- Better diagnostics list than default — navigable panel of all errors/warnings
- Essential for TypeScript projects with cascading type errors
- `<leader>xx` workspace, `<leader>xd` buffer, `<leader>xq` quickfix

### 3. nvim-spectre — Project-wide find & replace
- Regex-powered search and replace across entire project with live preview
- `<leader>sr` open, `<leader>sw` search word/selection

### 4. todo-comments.nvim — TODO/FIXME highlighting & search
- Highlights TODO/FIXME/HACK/NOTE/WARN in code with colors
- Searchable via Telescope (`<leader>td`) and Trouble (`<leader>tl`)
- Jump between TODOs with `]t` / `[t`

## Why
- **avante** fills the biggest gap: Copilot autocompletes lines, but there's no way to contextually chat with an LLM about code without leaving neovim
- **trouble** is essential for navigating TypeScript diagnostic hell
- **spectre** saves serious time when renaming across many files
- **todo-comments** pairs with our practice of creating issues for follow-up work