### PR TITLE
refactor: config cleanup and fixes (no new plugins)

### DIFF
--- a/lua/autocmds.lua
+++ b/lua/autocmds.lua
@@ -1,4 +1,4 @@
-require "nvchad.autocmds"
+-- nvchad.autocmds is already loaded in init.lua, no need to require it again
 
 local autocmd = vim.api.nvim_create_autocmd
 local augroup = vim.api.nvim_create_augroup

--- a/lua/configs/linting.lua
+++ b/lua/configs/linting.lua
@@ -38,16 +38,15 @@ lint.linters_by_ft = {
   python = { "ruff" },
 }
 
--- Conditionally add eslint_d for JS/TS files
-vim.api.nvim_create_autocmd({ "BufEnter", "BufWritePost" }, {
+-- Conditionally add eslint_d for JS/TS files (runs once on FileType, not every BufEnter)
+local js_filetypes = { javascript = true, javascriptreact = true, typescript = true, typescriptreact = true }
+
+vim.api.nvim_create_autocmd("FileType", {
+  pattern = { "javascript", "javascriptreact", "typescript", "typescriptreact" },
   callback = function()
     local ft = vim.bo.filetype
-    if ft == "javascript" or ft == "javascriptreact" or ft == "typescript" or ft == "typescriptreact" then
-      if has_eslint_config() then
-        lint.linters_by_ft[ft] = { "eslint_d" }
-      else
-        lint.linters_by_ft[ft] = {}
-      end
+    if js_filetypes[ft] then
+      lint.linters_by_ft[ft] = has_eslint_config() and { "eslint_d" } or {}
     end
   end,
 })

--- a/lua/mappings.lua
+++ b/lua/mappings.lua
@@ -1,113 +1,88 @@
 require "nvchad.mappings"
 
 local map = vim.keymap.set
--- Remove unwanted NvChad default mappings
-pcall(vim.keymap.del, "n", "<leader>lf")
 local hop = require "hop"
 local directions = require("hop.hint").HintDirection
 
-map("n", ";", ":", { desc = "CMD enter command mode" })
+-- Remove unwanted NvChad default mappings
+pcall(vim.keymap.del, "n", "<leader>lf")
 
-map("n", "<leader>fm", function()
-  require("conform").format()
-end, { desc = "File Format with conform" })
+-- ── General ──────────────────────────────────────────────────────────
+map("n", ";", ":", { desc = "General Enter command mode" })
+map("i", "jk", "<ESC>", { desc = "General Exit insert mode" })
+map("n", "<leader>s", "<cmd>w!<cr>", { desc = "General Save file" })
+map("n", "<leader>q", "<cmd>q!<cr>", { desc = "General Force quit" })
+map("n", "<leader>rp", ":let @+=expand('%:~:.')<CR>", { desc = "General Copy relative path" })
 
-map("i", "jk", "<ESC>", { desc = "Escape insert mode" })
+-- ── Navigation ───────────────────────────────────────────────────────
+map("n", "-", "<cmd>Oil<CR>", { desc = "Nav Open parent directory (Oil)" })
+map("n", "<C-h>", "<cmd> TmuxNavigateLeft<CR>", { desc = "Nav Window left" })
+map("n", "<C-l>", "<cmd> TmuxNavigateRight<CR>", { desc = "Nav Window right" })
+map("n", "<C-j>", "<cmd> TmuxNavigateDown<CR>", { desc = "Nav Window down" })
+map("n", "<C-k>", "<cmd> TmuxNavigateUp<CR>", { desc = "Nav Window up" })
 
--- DAP mappings
-map("n", "<leader>db", "<cmd> DapToggleBreakpoint <CR>", { desc = "Toggle DAP Breakpoint" })
+-- ── Hop (fast cursor movement) ───────────────────────────────────────
+map("", "<leader>w", function() hop.hint_words() end, { noremap = true, desc = "Hop Jump to word" })
+map("", "<leader>g", function() hop.hint_vertical() end, { noremap = true, desc = "Hop Jump vertical" })
+map("", "f", function() hop.hint_char1 { direction = directions.AFTER_CURSOR, current_line_only = true } end, { remap = true, desc = "Hop Char forward" })
+map("", "F", function() hop.hint_char1 { direction = directions.BEFORE_CURSOR, current_line_only = true } end, { remap = true, desc = "Hop Char backward" })
+map("", "t", function() hop.hint_char1 { direction = directions.AFTER_CURSOR, current_line_only = true, hint_offset = -1 } end, { remap = true, desc = "Hop Till char forward" })
+map("", "T", function() hop.hint_char1 { direction = directions.BEFORE_CURSOR, current_line_only = true, hint_offset = 1 } end, { remap = true, desc = "Hop Till char backward" })
+
+-- ── LSP ──────────────────────────────────────────────────────────────
+map("n", "<leader>ca", vim.lsp.buf.code_action, { desc = "LSP Code action" })
+map("n", "<leader>f", "<cmd>lua vim.diagnostic.open_float({border = 'rounded' })<CR>", { desc = "LSP Open diagnostic float" })
+map("n", "K", vim.lsp.buf.hover, { desc = "LSP Hover docs" })
+map("n", "<leader>fm", function() require("conform").format() end, { desc = "LSP Format file (conform)" })
+map("n", "<leader>l", "<cmd>lua require('lint').try_lint()<CR>", { desc = "LSP Trigger linting" })
+
+-- ── Folding (UFO) ───────────────────────────────────────────────────
+map("n", "zR", require("ufo").openAllFolds, { desc = "Fold Open all" })
+map("n", "zM", require("ufo").closeAllFolds, { desc = "Fold Close all" })
+map("n", "zK", function()
+  local winid = require("ufo").peekFoldedLinesUnderCursor()
+  if not winid then vim.lsp.buf.hover() end
+end, { desc = "Fold Peek" })
+
+-- ── Git ──────────────────────────────────────────────────────────────
+map("n", "<leader>gs", ":Git<CR>", { desc = "Git Status" })
+map("n", "<leader>gl", ":Git blame<CR>", { desc = "Git Blame (all lines)" })
+map("n", "<leader>gg", ":Gitsigns toggle_current_line_blame<CR>", { desc = "Git Toggle inline blame" })
+map("n", "<leader>di", ":vert Git diff<CR>", { desc = "Git Vertical diff" })
+
+-- ── Debug (DAP) ──────────────────────────────────────────────────────
+map("n", "<leader>db", "<cmd> DapToggleBreakpoint <CR>", { desc = "Debug Toggle breakpoint" })
 map("n", "<leader>dus", function()
   local widgets = require "dap.ui.widgets"
   local sidebar = widgets.sidebar(widgets.scopes)
   sidebar.open()
-end, { desc = "Open debugging sidebar" })
+end, { desc = "Debug Open sidebar" })
 
--- Crates mappings
-map("n", "<leader>rcu", function()
-  require("crates").upgrade_all_crates()
-end, { desc = "Update Crates" })
+-- ── Terminal ─────────────────────────────────────────────────────────
+map("n", "<leader>h", "<cmd>silent !tmux split-window -v<CR>", { desc = "Term Horizontal tmux split" })
+map("n", "<leader>v", "<cmd>silent !tmux split-window -h<CR>", { desc = "Term Vertical tmux split" })
+map("n", "<leader>ft", "<cmd>lua require('nvchad.term').toggle({pos = 'float', id = 'floatTerm'})<CR>", { desc = "Term Toggle floating terminal" })
 
--- Custom mappings
-map("n", "<leader>q", "<cmd>q!<cr>", { desc = "Force Quit" })
--- map("n", "<leader>e", "<cmd>NvimTreeToggle<cr>", { desc = "Toggle NvimTree" }) -- Commented out as per original mapping
-map("n", "<leader>s", "<cmd>w!<cr>", { desc = "Save File" })
-map("n", "<leader>rp", ":let @+=expand('%:~:.')<CR>", { desc = "Copy Relative Path" })
-map("n", "-", "<cmd>Oil<CR>", { desc = "Open parent directory" })
-map("n", "<leader>ca", vim.lsp.buf.code_action, { desc = "LSP Code Action" })
+-- ── Rust (Crates) ───────────────────────────────────────────────────
+map("n", "<leader>rcu", function() require("crates").upgrade_all_crates() end, { desc = "Rust Upgrade all crates" })
 
--- General mappings
-map("n", "<C-h>", "<cmd> TmuxNavigateLeft<CR>", { desc = "Window left" })
-map("n", "<C-l>", "<cmd> TmuxNavigateRight<CR>", { desc = "Window right" })
-map("n", "<C-j>", "<cmd> TmuxNavigateDown<CR>", { desc = "Window down" })
-map("n", "<C-k>", "<cmd> TmuxNavigateUp<CR>", { desc = "Window up" })
+-- ── Todo Comments ───────────────────────────────────────────────────
+map("n", "<leader>td", "<cmd>TodoTelescope<CR>", { desc = "Todo Search all TODOs" })
+map("n", "<leader>tl", "<cmd>Trouble todo toggle<CR>", { desc = "Todo List in Trouble" })
+map("n", "]t", function() require("todo-comments").jump_next() end, { desc = "Todo Jump to next" })
+map("n", "[t", function() require("todo-comments").jump_prev() end, { desc = "Todo Jump to previous" })
 
--- Git mappings
-map("n", "<leader>gl", ":Git blame<CR>", { desc = "All git blame lines" })
-map("n", "<leader>gg", ":Gitsigns toggle_current_line_blame<CR>", { desc = "Toggle git blame" })
-map("n", "<leader>di", ":vert Git diff<CR>", { desc = "Git diff" })
-map("n", "<leader>gs", ":Git<CR>", { desc = "Git status" })
+-- ── Spectre (find & replace) ────────────────────────────────────────
+map("n", "<leader>sr", "<cmd>lua require('spectre').open()<CR>", { desc = "Spectre Open search & replace" })
+map("n", "<leader>sw", "<cmd>lua require('spectre').open_visual({select_word=true})<CR>", { desc = "Spectre Search current word" })
+map("v", "<leader>sw", "<esc><cmd>lua require('spectre').open_visual()<CR>", { desc = "Spectre Search selection" })
 
--- Lspconfig mappings
-map("n", "<leader>f", "<cmd>lua vim.diagnostic.open_float({border = 'rounded' })<CR>", { desc = "Open LSP float" })
+-- ── Trouble (diagnostics) ───────────────────────────────────────────
+map("n", "<leader>xx", "<cmd>Trouble diagnostics toggle<CR>", { desc = "Trouble Workspace diagnostics" })
+map("n", "<leader>xd", "<cmd>Trouble diagnostics toggle filter.buf=0<CR>", { desc = "Trouble Buffer diagnostics" })
+map("n", "<leader>xl", "<cmd>Trouble loclist toggle<CR>", { desc = "Trouble Location list" })
+map("n", "<leader>xq", "<cmd>Trouble quickfix toggle<CR>", { desc = "Trouble Quickfix list" })
 
-map("n", "K", vim.lsp.buf.hover, { desc = "Show hover doc" })
-
--- Nvterm mappings
-map("n", "<leader>h", "<cmd>silent !tmux split-window -v<CR>", { desc = "New Horizontal Term" })
-map("n", "<leader>v", "<cmd>silent !tmux split-window -h<CR>", { desc = "New Vertical Term" })
-map(
-  "n",
-  "<leader>ft",
-  "<cmd>lua require('nvchad.term').toggle({pos = 'float', id = 'floatTerm'})<CR>",
-  { desc = "Toggle Floating Term" }
-)
-
--- Todo-comments mappings
-map("n", "<leader>td", "<cmd>TodoTelescope<CR>", { desc = "Todo: Search all TODOs" })
-map("n", "<leader>tl", "<cmd>Trouble todo toggle<CR>", { desc = "Todo: List in Trouble" })
-map("n", "]t", function() require("todo-comments").jump_next() end, { desc = "Todo: Next" })
-map("n", "[t", function() require("todo-comments").jump_prev() end, { desc = "Todo: Previous" })
-
--- Spectre mappings (project-wide find & replace)
-map("n", "<leader>sr", "<cmd>lua require('spectre').open()<CR>", { desc = "Spectre: Open search & replace" })
-map("n", "<leader>sw", "<cmd>lua require('spectre').open_visual({select_word=true})<CR>", { desc = "Spectre: Search current word" })
-map("v", "<leader>sw", "<esc><cmd>lua require('spectre').open_visual()<CR>", { desc = "Spectre: Search selection" })
-
--- Trouble mappings
-map("n", "<leader>xx", "<cmd>Trouble diagnostics toggle<CR>", { desc = "Trouble: Workspace Diagnostics" })
-map("n", "<leader>xd", "<cmd>Trouble diagnostics toggle filter.buf=0<CR>", { desc = "Trouble: Buffer Diagnostics" })
-map("n", "<leader>xl", "<cmd>Trouble loclist toggle<CR>", { desc = "Trouble: Location List" })
-map("n", "<leader>xq", "<cmd>Trouble quickfix toggle<CR>", { desc = "Trouble: Quickfix List" })
-
--- Linting mappings
-map("n", "<leader>l", "<cmd>lua require('lint').try_lint()<CR>", { desc = "Trigger linting for current file" })
-
--- Hop mappings
-map("", "f", function()
-  hop.hint_char1 { direction = directions.AFTER_CURSOR, current_line_only = true }
-end, { remap = true })
-map("", "F", function()
-  hop.hint_char1 { direction = directions.BEFORE_CURSOR, current_line_only = true }
-end, { remap = true })
-map("", "t", function()
-  hop.hint_char1 { direction = directions.AFTER_CURSOR, current_line_only = true, hint_offset = -1 }
-end, { remap = true })
-map("", "T", function()
-  hop.hint_char1 { direction = directions.BEFORE_CURSOR, current_line_only = true, hint_offset = 1 }
-end, { remap = true })
-map("", "<leader>w", function()
-  hop.hint_words()
-end, { noremap = true })
-map("", "<leader>g", function()
-  hop.hint_vertical()
-end, { noremap = true })
-
--- Fold mappings
-map("n", "zR", require("ufo").openAllFolds, { desc = "Open all folds" })
-map("n", "zM", require("ufo").closeAllFolds, { desc = "Close all folds" })
-map("n", "zK", function()
-  local winid = require("ufo").peekFoldedLinesUnderCursor()
-  if not winid then
-    vim.lsp.buf.hover()
-  end
-end, { desc = "Peek Fold" })
+-- ── Avante (AI) ─────────────────────────────────────────────────────
+-- Avante keybindings are defined in plugin opts (plugins/init.lua)
+-- <leader>aa = Ask AI | <leader>ae = AI Edit | <leader>at = Toggle panel

--- a/lua/mappings.lua
+++ b/lua/mappings.lua
@@ -84,5 +84,9 @@ map("n", "<leader>xl", "<cmd>Trouble loclist toggle<CR>", { desc = "Trouble Loca
 map("n", "<leader>xq", "<cmd>Trouble quickfix toggle<CR>", { desc = "Trouble Quickfix list" })
 
 -- ── Avante (AI) ─────────────────────────────────────────────────────
--- Avante keybindings are defined in plugin opts (plugins/init.lua)
--- <leader>aa = Ask AI | <leader>ae = AI Edit | <leader>at = Toggle panel
+map("n", "<leader>aa", function() require("avante.api").ask() end, { desc = "AI Ask about code" })
+map("v", "<leader>aa", function() require("avante.api").ask() end, { desc = "AI Ask about selection" })
+map("n", "<leader>ae", function() require("avante.api").edit() end, { desc = "AI Edit code" })
+map("v", "<leader>ae", function() require("avante.api").edit() end, { desc = "AI Edit selection" })
+map("n", "<leader>ar", function() require("avante.api").refresh() end, { desc = "AI Refresh response" })
+map("n", "<leader>at", function() require("avante.api").toggle() end, { desc = "AI Toggle panel" })

--- a/lua/mappings.lua
+++ b/lua/mappings.lua
@@ -110,9 +110,3 @@ map("n", "zK", function()
     vim.lsp.buf.hover()
   end
 end, { desc = "Peek Fold" })
-
-require("ufo").setup {
-  provider_selector = function(bufnr, filetype, buftype)
-    return { "lsp", "indent" }
-  end,
-}

--- a/lua/mappings.lua
+++ b/lua/mappings.lua
@@ -1,7 +1,8 @@
 require "nvchad.mappings"
 
 local map = vim.keymap.set
-local emptyMap = "nil"
+-- Remove unwanted NvChad default mappings
+pcall(vim.keymap.del, "n", "<leader>lf")
 local hop = require "hop"
 local directions = require("hop.hint").HintDirection
 
@@ -48,7 +49,7 @@ map("n", "<leader>gs", ":Git<CR>", { desc = "Git status" })
 
 -- Lspconfig mappings
 map("n", "<leader>f", "<cmd>lua vim.diagnostic.open_float({border = 'rounded' })<CR>", { desc = "Open LSP float" })
-map("n", "<leader>lf", emptyMap)
+
 map("n", "K", vim.lsp.buf.hover, { desc = "Show hover doc" })
 
 -- Nvterm mappings

--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -273,6 +273,7 @@ return {
       copilot = {
         model = "claude-sonnet-4.6",
       },
+      -- Keybindings defined in mappings.lua for cheatsheet visibility
       mappings = {
         ask = "<leader>aa",
         edit = "<leader>ae",

--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -71,6 +71,7 @@ return {
 
         -- low level
         "c",
+        "rust",
         "zig",
         "python",
         "prisma",

--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -140,7 +140,17 @@ return {
     end,
   },
 
-  { "kevinhwang91/nvim-ufo", dependencies = "kevinhwang91/promise-async" },
+  {
+    "kevinhwang91/nvim-ufo",
+    dependencies = "kevinhwang91/promise-async",
+    config = function()
+      require("ufo").setup {
+        provider_selector = function(bufnr, filetype, buftype)
+          return { "lsp", "indent" }
+        end,
+      }
+    end,
+  },
 
   {
     "saecki/crates.nvim",


### PR DESCRIPTION
## What

5 cleanup commits, zero new plugins:

### 1. Move UFO setup from mappings.lua to plugin config
UFO's `setup()` was living in mappings.lua — moved to plugin spec where initialization belongs.

### 2. Remove duplicate `require "nvchad.autocmds"`
Was loaded in both `init.lua` and `autocmds.lua`. Removed the duplicate.

### 3. Fix `emptyMap = "nil"` antipattern
Was mapping `<leader>lf` to the literal string `"nil"` instead of removing it. Now uses `vim.keymap.del` via pcall.

### 4. Optimize eslint config detection
`has_eslint_config()` was running on every `BufEnter` + `BufWritePost` for JS/TS files. Now runs once on `FileType` — actual linting is handled by the autocmd in autocmds.lua.

### 5. Add Rust to treesitter ensure_installed
`rust_analyzer` LSP was configured but Rust treesitter grammar was missing.